### PR TITLE
Add troubleshooting tip: firewall

### DIFF
--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -182,6 +182,10 @@ Configure _socket activation_ for TCP ports 80 and 443.
    192.168.10.161
    ```
    __result:__ The IPv4 address of the other computer matches the IPv4 address of _X-Forwarded-For_ and _X-Real-Ip_
+   
+   __troubleshooting tip:__ If the curl command fails with `Connection timed out` or `Connection refused`,
+   then there is probably a firewall blocking the connection. How to open up the firewall is beyond
+   the scope of this tutorial.
 
 ### Using `Internal=true`
 


### PR DESCRIPTION
curl errors `Connection timed out` and `Connection refused` might be caused by a firewall.

Fixes: https://github.com/eriksjolund/podman-traefik-socket-activation/issues/11