### PR TITLE
Add workaround for traefik issue 7347

### DIFF
--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -84,6 +84,16 @@ Configure _socket activation_ for TCP ports 80 and 443.
    ```
    systemctl --user start whoami.service
    ```
+1. Start the _traefik_ container
+   ```
+   systemctl --user start mytraefik.service
+   ```
+   This step was added due to traefik issue [7347](https://github.com/traefik/traefik/issues/7347).
+1. Wait a few seconds
+   ```
+   sleep 3
+   ```
+   This is also related to traefik issue [7347](https://github.com/traefik/traefik/issues/7347). Traefik sends `READY=1` before traefik is ready.
 1. Download a web page __http://whoami__ from the traefik
    container and see that the request is proxied to the container _whoami_.
    Resolve _whoami_ to _127.0.0.1_.


### PR DESCRIPTION
Add a workaround for 

* https://github.com/traefik/traefik/issues/7347

 to avoid getting HTTP response 404 during the first seconds when traefik is starting up.

