### PR TITLE
Remove explicit '0.0.0.0' IP address from example socket configurations

### DIFF
--- a/examples/example1/http.socket
+++ b/examples/example1/http.socket
@@ -1,6 +1,6 @@
 [Socket]
 
-ListenStream=0.0.0.0:80
+ListenStream=80
 FileDescriptorName=web
 Service=mytraefik.service
 

--- a/examples/example1/https.socket
+++ b/examples/example1/https.socket
@@ -1,6 +1,6 @@
 [Socket]
 
-ListenStream=0.0.0.0:443
+ListenStream=443
 FileDescriptorName=websecure
 Service=mytraefik.service
 


### PR DESCRIPTION
Having 0.0.0.0 as the IP address causes the socket to listen only on IPv4 interfaces. Removing it makes it listen on both IPv4 and IPv6 interfaces