### PR TITLE
Add `Options=isolate=true` to network quadlets

### DIFF
--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -215,6 +215,7 @@ The file [_mynet.network_](mynet.network) currently contains
 
 ```
 [Network]
+Options=isolate=true
 Internal=true
 ```
 

--- a/examples/example1/mynet.network
+++ b/examples/example1/mynet.network
@@ -1,2 +1,3 @@
 [Network]
+Options=isolate=true
 Internal=true

--- a/examples/example2/mynet.network
+++ b/examples/example2/mynet.network
@@ -1,3 +1,4 @@
 [Network]
 NetworkName=mynet
+Options=isolate=true
 # Internal=true


### PR DESCRIPTION
Containers in different custom networks can't connect to each other if the networks
were created with `--opt=isolate=strict`