### PR TITLE
example1: use whoami.example.com and add label

### DIFF
--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -6,7 +6,7 @@ return to [main page](../..)
 graph TB
 
     a1[curl] -.->a2[traefik container reverse proxy]
-    a2 -->|"for http&colon;//whoami"| a3["whoami container"]
+    a2 -->|"for http&colon;//whoami.example.com"| a3["whoami container"]
 ```
 
 Set up a systemd user service _example1.service_ for the user _test_ where rootless podman is running the container image _localhost/traefik_.
@@ -106,11 +106,11 @@ Requirements:
    sleep 3
    ```
    This is also related to traefik issue [7347](https://github.com/traefik/traefik/issues/7347). Traefik sends `READY=1` before traefik is ready.
-1. Download a web page __http://whoami__ from the traefik
+1. Download a web page __http://whoami.example.com__ from the traefik
    container and see that the request is proxied to the container _whoami_.
-   Resolve _whoami_ to _127.0.0.1_.
+   Resolve _whoami.example.com_ to _127.0.0.1_.
    ```
-   $ curl -s --resolve whoami:80:127.0.0.1 http://whoami:80
+   $ curl -s --resolve whoami.example.com:80:127.0.0.1 http://whoami.example.com:80
    Hostname: 0315603f400d
    IP: 127.0.0.1
    IP: ::1
@@ -118,12 +118,12 @@ Requirements:
    IP: fe80::18fe:c3ff:fe9e:d8ee
    RemoteAddr: 10.89.0.3:37168
    GET / HTTP/1.1
-   Host: whoami
+   Host: whoami.example.com
    User-Agent: curl/8.6.0
    Accept: */*
    Accept-Encoding: gzip
    X-Forwarded-For: 127.0.0.1
-   X-Forwarded-Host: whoami
+   X-Forwarded-Host: whoami.example.com
    X-Forwarded-Port: 80
    X-Forwarded-Proto: http
    X-Forwarded-Server: 046d07b93fc9
@@ -140,12 +140,12 @@ Requirements:
    192.168.10.108 192.168.39.1 192.168.122.1 fd25:c7f8:948a:0:912d:3900:d5c4:45ad
    ```
    __result:__ The IPv4 address of the main network interface is _192.168.10.108_ (the address furthest to the left)
-1. Download a web page __http://whoami__ from the traefik
+1. Download a web page __http://whoami.example.com__ from the traefik
    container and see that the request is proxied to the container _whoami_.
-   Resolve _whoami_ to the IP address of the main network interface.
+   Resolve _whoami.example.com_ to the IP address of the main network interface.
    Run the command
    ```
-   curl --resolve whoami:80:192.168.10.108 http://whoami
+   curl --resolve whoami.example.com:80:192.168.10.108 http://whoami.example.com
    ```
    The following output is printed
    ```
@@ -156,12 +156,12 @@ Requirements:
    IP: fe80::18fe:c3ff:fe9e:d8ee
    RemoteAddr: 10.89.0.3:37168
    GET / HTTP/1.1
-   Host: whoami
+   Host: whoami.example.com
    User-Agent: curl/8.6.0
    Accept: */*
    Accept-Encoding: gzip
    X-Forwarded-For: 192.168.10.108
-   X-Forwarded-Host: whoami
+   X-Forwarded-Host: whoami.example.com
    X-Forwarded-Port: 80
    X-Forwarded-Proto: http
    X-Forwarded-Server: 046d07b93fc9
@@ -169,10 +169,10 @@ Requirements:
    ```
    __result:__ The IPv4 address of the main network interface, _192.168.10.108_, matches the IPv4 address
    of _X-Forwarded-For_ and _X-Real-Ip_
-1. From another computer download a web page __http://whoami__ from the traefik
+1. From another computer download a web page __http://whoami.example.com__ from the traefik
    container and see that the request is proxied to the container _whoami_.
    ```
-   curl --resolve whoami:80:192.168.10.108 http://whoami
+   curl --resolve whoami.example.com:80:192.168.10.108 http://whoami.example.com
    ```
    The following output is printed
    ```
@@ -183,12 +183,12 @@ Requirements:
    IP: fe80::18fe:c3ff:fe9e:d8ee
    RemoteAddr: 10.89.0.3:42586
    GET / HTTP/1.1
-   Host: whoami
+   Host: whoami.example.com
    User-Agent: curl/8.7.1
    Accept: */*
    Accept-Encoding: gzip
    X-Forwarded-For: 192.168.10.161
-   X-Forwarded-Host: whoami
+   X-Forwarded-Host: whoami.example.com
    X-Forwarded-Port: 80
    X-Forwarded-Proto: http
    X-Forwarded-Server: 046d07b93fc9

--- a/examples/example1/whoami.container
+++ b/examples/example1/whoami.container
@@ -3,3 +3,4 @@ Image=docker.io/traefik/whoami
 ContainerName=whoami
 Network=mynet.network
 Label="traefik.enable=true"
+Label="traefik.http.routers.whoami.rule=Host(`whoami.example.com`)"


### PR DESCRIPTION
Use `http://whoami.example.com` instead of `http://whoami`
in the curl commands.

Add label in _whoami.container_