### PR TITLE
docker.io/traefik/traefik -> docker.io/library/traefik

### DIFF
--- a/examples/example2/traefik.container
+++ b/examples/example2/traefik.container
@@ -9,7 +9,7 @@ Sockets=http.socket https.socket
 NetworkAlias=whoami.example.com
 NoNewPrivileges=true
 ReadOnly=true
-Image=docker.io/traefik/traefik
+Image=docker.io/library/traefik
 Network=mynet.network
 
 Volume=%h/traefik.yaml:/etc/traefik/traefik.yml:Z


### PR DESCRIPTION
Use the container image
docker.io/library/traefik
instead of
docker.io/traefik/traefik

Rationale:
docker.io/library/traefik is more popular than
docker.io/traefik/traefik in the forum
https://community.traefik.io/

I beleive the images are identical.