### PR TITLE
Prefer `isolate=strict` to `isolate=true`

### DIFF
--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -215,7 +215,7 @@ The file [_mynet.network_](mynet.network) currently contains
 
 ```
 [Network]
-Options=isolate=true
+Options=isolate=strict
 Internal=true
 ```
 

--- a/examples/example1/mynet.network
+++ b/examples/example1/mynet.network
@@ -1,3 +1,3 @@
 [Network]
-Options=isolate=true
+Options=isolate=strict
 Internal=true

--- a/examples/example2/mynet.network
+++ b/examples/example2/mynet.network
@@ -1,4 +1,4 @@
 [Network]
 NetworkName=mynet
-Options=isolate=true
+Options=isolate=strict
 # Internal=true


### PR DESCRIPTION
Fixing a small mistake. Actually, I wanted to write

```
Options=isolate=strict
```

when I added those options before.
Somehow, I mixed it up and wrote

```
Options=isolate=true
```

In any case, it's not a big difference. The value `strict` is more restricted.
For details, see
https://github.com/eriksjolund/podman-networking-docs#custom-network-option-isolate

__Side note:__ 
In Podman 6.0 the new default value is `strict` instead of `true`.